### PR TITLE
Issue #41: Fix typo

### DIFF
--- a/IRI.php
+++ b/IRI.php
@@ -497,7 +497,7 @@ class IRI
         // http://tools.ietf.org/html/rfc3986#appendix-B
         $regex = '|^((?P<scheme>[^:/?#]+):)?' .
                     '((?P<doubleslash>//)(?P<authority>[^/?#]*))?(?P<path>[^?#]*)' .
-                    '((?<querydef>\?)(?P<query>[^#]*))?(#(?P<fragment>.*))?|';
+                    '((?P<querydef>\?)(?P<query>[^#]*))?(#(?P<fragment>.*))?|';
         preg_match($regex, $iri, $match);
 
         // Extract scheme


### PR DESCRIPTION
_I suppose_ the variation in syntax is only a typo - the changed one works on older versions of PCRE.
